### PR TITLE
fixed Cayman Islands space for the country code

### DIFF
--- a/MRCountryPicker/Assets/SwiftCountryPicker.bundle/Data/countryCodes.json
+++ b/MRCountryPicker/Assets/SwiftCountryPicker.bundle/Data/countryCodes.json
@@ -196,7 +196,7 @@
 },
 {
 "name": "Cayman Islands",
-"dial_code": "+ 345",
+"dial_code": "+345",
 "code": "KY"
 },
 {


### PR DESCRIPTION
Hi @xtrinch, I'm using your library in my project and noticed that all of the country codes are `+xxxx` except for the Cayman Islands one which had a space after the plus. This PR fixes it.

Thanks for a great component.