### PR TITLE
Update countryCodes.json

### DIFF
--- a/MRCountryPicker/Assets/SwiftCountryPicker.bundle/Data/countryCodes.json
+++ b/MRCountryPicker/Assets/SwiftCountryPicker.bundle/Data/countryCodes.json
@@ -301,7 +301,7 @@
 },
 {
 "name": "Dominican Republic",
-"dial_code": "+1849",
+"dial_code": "+1",
 "code": "DO"
 },
 {


### PR DESCRIPTION
The country code for Dominican Republic must be +1 instead +1849.

Closes #24 